### PR TITLE
Fixed oOuch http client does not need to call free

### DIFF
--- a/addons/twitcher/lib/oOuch/http_client.gd
+++ b/addons/twitcher/lib/oOuch/http_client.gd
@@ -75,7 +75,6 @@ func connect_to_host() -> void:
 func shutdown() -> void:
 	client.close();
 	Engine.get_main_loop().process_frame.disconnect(_poll);
-	free();
 
 ## Starts a request that will be handled as soon as the client gets free.
 ## Use HTTPClient.METHOD_* for the method.

--- a/addons/twitcher/lib/oOuch/http_client.gd
+++ b/addons/twitcher/lib/oOuch/http_client.gd
@@ -71,11 +71,6 @@ func connect_to_host() -> void:
 	if err != OK:
 		logError("Can't connect to %s cause of %s" % [base_url, error_string(err)]);
 
-## Removes the complete http client. Don't use it after calling this method!
-func shutdown() -> void:
-	client.close();
-	Engine.get_main_loop().process_frame.disconnect(_poll);
-
 ## Starts a request that will be handled as soon as the client gets free.
 ## Use HTTPClient.METHOD_* for the method.
 func request(path: String, method: int, headers: Dictionary, body: String) -> RequestData:


### PR DESCRIPTION
RefCounted objects are automatically freed and free does not need to be called. This causes the overlay to crash when exported, so I removed it.