### PR TITLE
ignore time scale when creating timers

### DIFF
--- a/addons/twitcher/lib/http/buffered_http_client.gd
+++ b/addons/twitcher/lib/http/buffered_http_client.gd
@@ -114,7 +114,7 @@ func _on_request_completed(result: int, response_code: int, headers: PackedStrin
 		var wait_time = pow(2, request_data.retry)
 		wait_time = min(wait_time, 30)
 		logDebug("Error happend during connection. Wait for %s" % wait_time)
-		await get_tree().create_timer(wait_time).timeout
+		await get_tree().create_timer(wait_time, true, false, true).timeout
 		var http_request: HTTPRequest = request_data.http_request.duplicate()
 		add_child(http_request)
 		request_data.http_request = http_request

--- a/addons/twitcher/lib/http/debug_buffered_http_client.gd
+++ b/addons/twitcher/lib/http/debug_buffered_http_client.gd
@@ -46,7 +46,7 @@ func _on_add_request(request: BufferedHTTPClient.RequestData, http_item: TreeIte
 func _on_done_request(response: BufferedHTTPClient.ResponseData):
 	var request_item = request_map[response.request_data] as TreeItem
 	request_item.set_text(1, "DONE")
-	await get_tree().create_timer(60).timeout
+	await get_tree().create_timer(60, true, false, true).timeout
 	if request_item != null: request_item.free()
 
 
@@ -54,5 +54,5 @@ func _close_client(client: BufferedHTTPClient):
 	var http_item = client_map[client] as TreeItem
 	client_map.erase(client)
 	http_item.set_text(1, "CLOSED")
-	await get_tree().create_timer(60).timeout
+	await get_tree().create_timer(60, true, false, true).timeout
 	http_item.free()

--- a/addons/twitcher/lib/http/websocket_client.gd
+++ b/addons/twitcher/lib/http/websocket_client.gd
@@ -63,7 +63,7 @@ func _establish_connection() -> void:
 	_is_already_connecting = true
 	var wait_time = pow(2, _tries)
 	_logDebug("Wait %s before connecting" % [wait_time])
-	await get_tree().create_timer(wait_time).timeout
+	await get_tree().create_timer(wait_time, true, false, true).timeout
 	_logInfo("Connecting to %s" % connection_url)
 	var err = _peer.connect_to_url(connection_url)
 	if err != OK:

--- a/addons/twitcher/lib/oOuch/oauth.gd
+++ b/addons/twitcher/lib/oOuch/oauth.gd
@@ -117,7 +117,7 @@ func login() -> void:
 
 	if _last_login_attempt != 0 && Time.get_ticks_msec() - 60 * 1000 < _last_login_attempt:
 		print("[OAuth] Last Login attempt was within 1 minute wait 1 minute before trying again. Please enable and consult logs, cause there is an issue with your authentication!")
-		await get_tree().create_timer(60).timeout
+		await get_tree().create_timer(60, true, false, true).timeout
 
 	_last_login_attempt = Time.get_ticks_msec()
 

--- a/addons/twitcher/lib/oOuch/oauth_token_handler.gd
+++ b/addons/twitcher/lib/oOuch/oauth_token_handler.gd
@@ -123,7 +123,7 @@ func request_device_token(device_code_repsonse: OAuthDeviceCodeResponse, scopes:
 			return
 		elif response.response_code == 400 && response_string.contains("authorization_pending"):
 			# Awaits for this amount of time until retry
-			await get_tree().create_timer(device_code_repsonse.interval).timeout
+			await get_tree().create_timer(device_code_repsonse.interval, true, false, true).timeout
 		elif response.response_code == 400:
 			unauthenticated.emit()
 			_requesting_token = false


### PR DESCRIPTION
When using different time scales, the timer act differently. This solves this problem.

This could be added as a helper function to just call something like `helper.create_timer(time)` but I don't know where to put it so for now I kept it like this.