### PR TITLE
Fixed access token always invalid for Implicit Grant Flow.

### DIFF
--- a/addons/twitcher/auth/twitch_token_handler.gd
+++ b/addons/twitcher/auth/twitch_token_handler.gd
@@ -24,8 +24,9 @@ func _check_token_refresh() -> void:
 ## Calles the validation endpoint of Twtich to make sure
 func _validate_token() -> void:
 	_last_validation_check = Time.get_ticks_msec() + 60 * 60 * 1000;
+	var access_token = token._access_token # we need to use the internal access token here cause the get_access_token method won't returned until the token is authorized 
 	var validation_request = _http_client.request("https://id.twitch.tv/oauth2/validate", HTTPClient.METHOD_GET, {
-		"Authorization": "OAuth %s" % await token.get_access_token()
+		"Authorization": "OAuth %s" % access_token
 	}, "")
 	var response = await _http_client.wait_for_request(validation_request)
 	if response.response_code != 200:
@@ -37,6 +38,10 @@ func _validate_token() -> void:
 	if response_data["expires_in"] <= 0:
 		refresh_tokens()
 		return
+	else:
+		# update expire date
+		token._expire_date = Time.get_unix_time_from_system() + response_data["expires_in"]
+		token.emit_changed()
 
 
 func revoke_token() -> void:

--- a/addons/twitcher/lib/oOuch/oauth.gd
+++ b/addons/twitcher/lib/oOuch/oauth.gd
@@ -276,6 +276,10 @@ func _process_implicit_request(client: OAuthHTTPServer.Client, server: OAuthHTTP
 		token_handler.update_tokens(token_request["access_token"])
 		logInfo("Received Access Token update it")
 		server.send_response(client, "200 OK", "<html><head><title>Login</title><script>window.close()</script></head><body>Success!</body></html>".to_utf8_buffer())
+		
+		# We didn't include the expire date in the update_tokens method above so we need to validate it
+		if token_handler is TwitchTokenHandler:
+			await token_handler._validate_token()
 
 #endregion
 #region AuthCodeFlow


### PR DESCRIPTION
In `_process_implicit_request` method, the `access_token` returned is added with default `expires_in`, it's never updated and thus always invalid. 

Added a `_validate_token()` call after adding the token. 

Use `token.access_token` directed instead of `token.get_access_token()` to as the code will wait until it's authorized, which is what we're trying to do right now.

Update `expire_date` of token from validation response.

https://github.com/kanimaru/twitcher/issues/75#issuecomment-3339355579